### PR TITLE
Apply 16 kHz resampling in inference scripts

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,2 @@
+"""Utility helpers shared across runnable scripts."""
+

--- a/scripts/convert_to_16k.py
+++ b/scripts/convert_to_16k.py
@@ -1,0 +1,92 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "julius",
+#     "numpy",
+#     "sphn",
+#     "torch",
+# ]
+# ///
+"""Utility script to resample audio to 16 kHz without altering playback speed."""
+
+import argparse
+from pathlib import Path
+
+import julius
+import numpy as np
+import sphn
+import torch
+
+TARGET_SAMPLE_RATE = 16_000
+
+
+def load_audio(path: Path) -> tuple[np.ndarray, int]:
+    """Return audio data as float32 PCM and the original sample rate."""
+    audio, sample_rate = sphn.read(str(path))
+
+    if audio.dtype != np.float32:
+        audio = audio.astype(np.float32)
+
+    return audio, int(sample_rate)
+
+
+def resample(audio: np.ndarray, src_rate: int) -> np.ndarray:
+    """Resample the provided audio to 16 kHz if needed."""
+    if src_rate == TARGET_SAMPLE_RATE:
+        return audio
+
+    audio_tensor = torch.from_numpy(audio)
+    resampled = julius.resample_frac(audio_tensor, src_rate, TARGET_SAMPLE_RATE)
+    return resampled.cpu().numpy().astype(np.float32, copy=False)
+
+
+def ensure_mono(audio: np.ndarray) -> np.ndarray:
+    if audio.ndim == 1:
+        return audio
+    if audio.shape[0] == 1:
+        return audio[0]
+    return audio.mean(axis=0)
+
+
+def load_resampled_audio(path: Path | str, *, keep_channels: bool = False) -> np.ndarray:
+    """Load ``path`` and return float32 PCM audio resampled to 16 kHz."""
+
+    audio, source_rate = load_audio(Path(path))
+
+    if keep_channels:
+        if audio.ndim == 1:
+            audio = audio[None, :]
+        resampled = resample(audio, source_rate)
+        if resampled.ndim == 1:
+            resampled = resampled[None, :]
+        return resampled.astype(np.float32, copy=False)
+
+    mono = ensure_mono(audio)
+    resampled = resample(mono, source_rate)
+    return resampled.astype(np.float32, copy=False)
+
+
+def save_audio(path: Path, audio: np.ndarray) -> None:
+    audio = np.clip(audio, -1.0, 1.0).astype(np.float32)
+    sphn.write_wav(str(path), audio, TARGET_SAMPLE_RATE)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=Path, help="Source audio file")
+    parser.add_argument("output", type=Path, help="Destination WAV file")
+    parser.add_argument(
+        "--keep-channels",
+        action="store_true",
+        help="Keep the original channel layout instead of mixing down to mono.",
+    )
+
+    args = parser.parse_args()
+
+    resampled = load_resampled_audio(args.input, keep_channels=args.keep_channels)
+
+    save_audio(args.output, resampled)
+    print(
+        f"Saved {args.output} at {TARGET_SAMPLE_RATE} Hz "
+        f"({resampled.shape[-1] / TARGET_SAMPLE_RATE:.2f}s)"
+    )

--- a/scripts/convert_to_16k.py
+++ b/scripts/convert_to_16k.py
@@ -1,46 +1,90 @@
 # /// script
 # requires-python = ">=3.10"
 # dependencies = [
-#     "julius",
+#     "scipy",
 #     "numpy",
 #     "sphn",
-#     "torch",
 # ]
 # ///
 """Utility script to resample audio to 16 kHz without altering playback speed."""
 
 import argparse
+from fractions import Fraction
 from pathlib import Path
 
-import julius
 import numpy as np
 import sphn
-import torch
+from scipy.signal import resample_poly
 
 TARGET_SAMPLE_RATE = 16_000
 
 
+def _ensure_channel_first(audio: np.ndarray) -> np.ndarray:
+    if audio.ndim == 1:
+        return audio
+
+    # Heuristic: treat small leading dimension as channel count; otherwise fall back to
+    # channel-last interpretation when the trailing dimension looks like the channels.
+    if audio.shape[0] <= audio.shape[-1] and audio.shape[0] <= 8:
+        return audio
+    if audio.shape[-1] <= 8:
+        return np.moveaxis(audio, -1, 0)
+    return audio
+
+
 def load_audio(path: Path) -> tuple[np.ndarray, int]:
     """Return audio data as float32 PCM and the original sample rate."""
+
     audio, sample_rate = sphn.read(str(path))
 
     if audio.dtype != np.float32:
         audio = audio.astype(np.float32)
 
+    audio = _ensure_channel_first(np.ascontiguousarray(audio))
+
     return audio, int(sample_rate)
+
+
+def _expected_length(num_samples: int, src_rate: int) -> int:
+    return int(round(num_samples * TARGET_SAMPLE_RATE / src_rate))
 
 
 def resample(audio: np.ndarray, src_rate: int) -> np.ndarray:
     """Resample the provided audio to 16 kHz if needed."""
-    if src_rate == TARGET_SAMPLE_RATE:
-        return audio
 
-    audio_tensor = torch.from_numpy(audio)
-    resampled = julius.resample_frac(audio_tensor, src_rate, TARGET_SAMPLE_RATE)
-    return resampled.cpu().numpy().astype(np.float32, copy=False)
+    if src_rate == TARGET_SAMPLE_RATE:
+        return audio.astype(np.float32, copy=False)
+
+    audio_for_resample = _ensure_channel_first(audio)
+    if audio_for_resample.ndim == 1:
+        audio_for_resample = audio_for_resample[None, :]
+
+    ratio = Fraction(TARGET_SAMPLE_RATE, src_rate).limit_denominator(1000)
+    resampled = resample_poly(
+        audio_for_resample,
+        ratio.numerator,
+        ratio.denominator,
+        axis=-1,
+    )
+
+    expected = _expected_length(audio_for_resample.shape[-1], src_rate)
+    if resampled.shape[-1] != expected:
+        diff = expected - resampled.shape[-1]
+        if diff < 0:
+            resampled = resampled[..., :expected]
+        else:
+            pad_width = [(0, 0)] * resampled.ndim
+            pad_width[-1] = (0, diff)
+            resampled = np.pad(resampled, pad_width)
+
+    if audio_for_resample.shape[0] == 1:
+        resampled = resampled[0]
+
+    return resampled.astype(np.float32, copy=False)
 
 
 def ensure_mono(audio: np.ndarray) -> np.ndarray:
+    audio = _ensure_channel_first(audio)
     if audio.ndim == 1:
         return audio
     if audio.shape[0] == 1:
@@ -59,11 +103,11 @@ def load_resampled_audio(path: Path | str, *, keep_channels: bool = False) -> np
         resampled = resample(audio, source_rate)
         if resampled.ndim == 1:
             resampled = resampled[None, :]
-        return resampled.astype(np.float32, copy=False)
+        return np.ascontiguousarray(resampled.astype(np.float32, copy=False))
 
     mono = ensure_mono(audio)
     resampled = resample(mono, source_rate)
-    return resampled.astype(np.float32, copy=False)
+    return np.ascontiguousarray(resampled.astype(np.float32, copy=False))
 
 
 def save_audio(path: Path, audio: np.ndarray) -> None:

--- a/scripts/stt_from_file_mlx.py
+++ b/scripts/stt_from_file_mlx.py
@@ -16,9 +16,10 @@ import json
 import mlx.core as mx
 import mlx.nn as nn
 import sentencepiece
-import sphn
 from huggingface_hub import hf_hub_download
 from moshi_mlx import models, utils
+
+from scripts.convert_to_16k import load_resampled_audio
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -30,7 +31,7 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    audio, _ = sphn.read(args.in_file, sample_rate=16000)
+    audio = load_resampled_audio(args.in_file, keep_channels=True)
     if args.hf_repo is None:
         if args.vad:
             args.hf_repo = "kyutai/stt-1b-en_fr-candle"

--- a/scripts/stt_from_file_rust_server.py
+++ b/scripts/stt_from_file_rust_server.py
@@ -13,17 +13,18 @@ import time
 
 import msgpack
 import numpy as np
-import sphn
 import websockets
+
+from scripts.convert_to_16k import load_resampled_audio
 
 SAMPLE_RATE = 16000
 FRAME_SIZE = 1280  # Send data in chunks
 
 
 def load_and_process_audio(file_path):
-    """Load an MP3 file, resample to 16kHz, convert to mono, and extract PCM float32 data."""
-    pcm_data, _ = sphn.read(file_path, sample_rate=SAMPLE_RATE)
-    return pcm_data[0]
+    """Load audio, resample to 16 kHz and return mono float32 PCM."""
+    pcm_data = load_resampled_audio(file_path)
+    return pcm_data
 
 
 async def receive_messages(websocket):


### PR DESCRIPTION
## Summary
- expose a reusable `load_resampled_audio` helper from the resampling utility
- reuse the helper in the MLX and Rust streaming clients so input audio is actually converted to 16 kHz
- add a package marker so other scripts can import the shared helper

## Testing
- python -m compileall scripts/convert_to_16k.py scripts/stt_from_file_mlx.py scripts/stt_from_file_rust_server.py

------
https://chatgpt.com/codex/tasks/task_e_68cec75530b88322aa00ff760b7a45a8