### PR TITLE
Add shared 8kHz resampling utility and converter script

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,5 @@
+"""Utility package for reusable script helpers."""
+
+from .audio_utils import load_resampled_audio
+
+__all__ = ["load_resampled_audio"]

--- a/scripts/audio_utils.py
+++ b/scripts/audio_utils.py
@@ -1,0 +1,59 @@
+"""Shared audio utilities for scripts."""
+
+from __future__ import annotations
+
+import julius
+import numpy as np
+import sphn
+import torch
+
+
+DEFAULT_TARGET_SAMPLE_RATE = 8_000
+
+
+def load_resampled_audio(
+    file_path: str,
+    target_sample_rate: int = DEFAULT_TARGET_SAMPLE_RATE,
+    mono: bool = False,
+    dtype: np.dtype | type = np.float32,
+) -> np.ndarray:
+    """Load audio and resample it to the target sample rate using Julius.
+
+    The returned array is channels-first with dtype ``float32`` (unless another dtype
+    is requested). Values are clipped to ``[-1, 1]`` to avoid downstream clipping
+    issues, and the duration is preserved by relying on Julius' fractional
+    resampling implementation.
+
+    Args:
+        file_path: Path to the audio file to load.
+        target_sample_rate: The desired sample rate for the returned audio.
+        mono: Whether to downmix multi-channel audio to mono by averaging channels.
+        dtype: The numpy dtype of the returned array.
+
+    Returns:
+        A numpy array of shape ``(channels, samples)`` containing float PCM data.
+    """
+
+    audio, input_sample_rate = sphn.read(file_path)
+    audio = np.asarray(audio)
+
+    if audio.ndim == 1:
+        audio = audio[None, :]
+
+    if mono and audio.shape[0] > 1:
+        audio = np.mean(audio, axis=0, keepdims=True)
+
+    audio_tensor = torch.from_numpy(audio.astype(np.float32, copy=False))
+
+    if int(input_sample_rate) != int(target_sample_rate):
+        audio_tensor = julius.resample_frac(
+            audio_tensor, int(input_sample_rate), int(target_sample_rate)
+        )
+
+    audio = audio_tensor.numpy()
+    audio = np.clip(audio, -1.0, 1.0)
+
+    if dtype is not None and audio.dtype != dtype:
+        audio = audio.astype(dtype, copy=False)
+
+    return audio

--- a/scripts/audio_utils.py
+++ b/scripts/audio_utils.py
@@ -1,5 +1,4 @@
 """Shared audio utilities for scripts."""
-
 from __future__ import annotations
 
 import julius
@@ -35,23 +34,40 @@ def load_resampled_audio(
     """
 
     audio, input_sample_rate = sphn.read(file_path)
-    audio = np.asarray(audio)
+    audio = np.asarray(audio, dtype=np.float32)
 
     if audio.ndim == 1:
         audio = audio[None, :]
 
     if mono and audio.shape[0] > 1:
-        audio = np.mean(audio, axis=0, keepdims=True)
+        audio = np.mean(audio, axis=0, keepdims=True, dtype=np.float32)
 
-    audio_tensor = torch.from_numpy(audio.astype(np.float32, copy=False))
+    audio = np.ascontiguousarray(audio)
+    input_sample_rate = int(input_sample_rate)
+    target_sample_rate = int(target_sample_rate)
 
-    if int(input_sample_rate) != int(target_sample_rate):
-        audio_tensor = julius.resample_frac(
-            audio_tensor, int(input_sample_rate), int(target_sample_rate)
-        )
+    audio_tensor = torch.from_numpy(audio)
+    expected_length: int | None = None
 
-    audio = audio_tensor.numpy()
+    if input_sample_rate != target_sample_rate:
+        original_length = audio_tensor.shape[-1]
+        expected_length = int(round(original_length * target_sample_rate / input_sample_rate))
+
+        resampler = julius.ResampleFrac(input_sample_rate, target_sample_rate)
+        resampler = resampler.to(audio_tensor)
+        audio_tensor = resampler(audio_tensor, output_length=expected_length)
+
+    audio = audio_tensor.detach().cpu().numpy()
     audio = np.clip(audio, -1.0, 1.0)
+
+    if expected_length is not None:
+        current_length = audio.shape[-1]
+        if current_length < expected_length:
+            pad_width = [(0, 0)] * audio.ndim
+            pad_width[-1] = (0, expected_length - current_length)
+            audio = np.pad(audio, pad_width, mode="constant")
+        elif current_length > expected_length:
+            audio = audio[..., :expected_length]
 
     if dtype is not None and audio.dtype != dtype:
         audio = audio.astype(dtype, copy=False)

--- a/scripts/convert_to_8k.py
+++ b/scripts/convert_to_8k.py
@@ -1,0 +1,49 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "julius",
+#     "numpy",
+#     "sphn",
+# ]
+# ///
+
+"""Utility to resample audio to 8kHz float PCM using Julius."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import sphn
+
+from scripts import load_resampled_audio
+
+TARGET_SAMPLE_RATE = 8_000
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=Path, help="Audio file to resample.")
+    parser.add_argument("output", type=Path, help="Path to write the resampled WAV file.")
+    parser.add_argument(
+        "--mono",
+        action="store_true",
+        help="Downmix to mono before resampling. The default keeps the original channel count.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    audio = load_resampled_audio(
+        str(args.input), target_sample_rate=TARGET_SAMPLE_RATE, mono=args.mono
+    )
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    sphn.write_wav(args.output, np.asarray(audio, dtype=np.float32), TARGET_SAMPLE_RATE)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/stt_from_file_mlx.py
+++ b/scripts/stt_from_file_mlx.py
@@ -1,6 +1,7 @@
 # /// script
 # requires-python = ">=3.12"
 # dependencies = [
+#     "julius",
 #     "huggingface_hub",
 #     "moshi_mlx==0.2.12",
 #     "numpy",
@@ -16,9 +17,9 @@ import json
 import mlx.core as mx
 import mlx.nn as nn
 import sentencepiece
-import sphn
 from huggingface_hub import hf_hub_download
 from moshi_mlx import models, utils
+from scripts import load_resampled_audio
 
 SAMPLE_RATE = 8000
 
@@ -32,7 +33,7 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    audio, _ = sphn.read(args.in_file, sample_rate=SAMPLE_RATE)
+    audio = load_resampled_audio(args.in_file, target_sample_rate=SAMPLE_RATE, mono=True)
     if args.hf_repo is None:
         if args.vad:
             args.hf_repo = "kyutai/stt-1b-en_fr-candle"

--- a/scripts/stt_from_file_rust_server.py
+++ b/scripts/stt_from_file_rust_server.py
@@ -1,6 +1,7 @@
 # /// script
 # requires-python = ">=3.12"
 # dependencies = [
+#     "julius",
 #     "msgpack",
 #     "numpy",
 #     "sphn",
@@ -13,7 +14,7 @@ import time
 
 import msgpack
 import numpy as np
-import sphn
+from scripts import load_resampled_audio
 import websockets
 
 SAMPLE_RATE = 8000
@@ -21,8 +22,8 @@ FRAME_SIZE = 1280  # Send data in chunks
 
 
 def load_and_process_audio(file_path):
-    """Load an MP3 file, resample to 8kHz, convert to mono, and extract PCM float32 data."""
-    pcm_data, _ = sphn.read(file_path, sample_rate=SAMPLE_RATE)
+    """Load an audio file and return clipped mono PCM data at 8kHz."""
+    pcm_data = load_resampled_audio(file_path, target_sample_rate=SAMPLE_RATE, mono=True)
     return pcm_data[0]
 
 


### PR DESCRIPTION
## Summary
- add a reusable `load_resampled_audio` helper and expose it from the `scripts` package
- introduce a `convert_to_8k.py` utility that resamples audio to 8 kHz with optional mono downmixing
- update the MLX file transcription and Rust streaming clients to use the shared resampling logic

## Testing
- python -m compileall scripts

------
https://chatgpt.com/codex/tasks/task_e_68cf77b0485c83229d1d19cbe96e20d2