### PR TITLE
Update streaming sample rate to 8kHz

### DIFF
--- a/scripts/stt_from_file_rust_server.py
+++ b/scripts/stt_from_file_rust_server.py
@@ -16,12 +16,12 @@ import numpy as np
 import sphn
 import websockets
 
-SAMPLE_RATE = 24000
-FRAME_SIZE = 1920  # Send data in chunks
+SAMPLE_RATE = 8000
+FRAME_SIZE = SAMPLE_RATE // 1000 * 80  # Send data in ~80ms chunks
 
 
 def load_and_process_audio(file_path):
-    """Load an MP3 file, resample to 24kHz, convert to mono, and extract PCM float32 data."""
+    """Load an MP3 file, resample to 8kHz, convert to mono, and extract PCM float32 data."""
     pcm_data, _ = sphn.read(file_path, sample_rate=SAMPLE_RATE)
     return pcm_data[0]
 

--- a/scripts/stt_from_mic_rust_server.py
+++ b/scripts/stt_from_mic_rust_server.py
@@ -16,7 +16,8 @@ import numpy as np
 import sounddevice as sd
 import websockets
 
-SAMPLE_RATE = 24000
+SAMPLE_RATE = 8000
+FRAME_SIZE = SAMPLE_RATE // 1000 * 80  # 80ms blocks
 
 # The VAD has several prediction heads, each of which tries to determine whether there
 # has been a pause of a given length. The lengths are 0.5, 1.0, 2.0, and 3.0 seconds.
@@ -83,7 +84,7 @@ async def stream_audio(url: str, api_key: str, show_vad: bool):
         channels=1,
         dtype="float32",
         callback=audio_callback,
-        blocksize=1920,  # 80ms blocks
+        blocksize=FRAME_SIZE,
     ):
         headers = {"kyutai-api-key": api_key}
         # Instead of using the header, you can authenticate by adding `?auth_id={api_key}` to the URL

--- a/scripts/tts_rust_server.py
+++ b/scripts/tts_rust_server.py
@@ -22,56 +22,89 @@ import websockets
 
 # The server currently streams audio at 24kHz. Downsample on the client so that the
 # saved or played audio uses the expected 8kHz cadence.
-SERVER_SAMPLE_RATE = 24000
+DEFAULT_SERVER_SAMPLE_RATE = 24000
 TARGET_SAMPLE_RATE = 8000
-TARGET_FRAME_SIZE = TARGET_SAMPLE_RATE // 1000 * 80
-_DOWNSAMPLE_FACTOR = SERVER_SAMPLE_RATE // TARGET_SAMPLE_RATE
-_DOWNSAMPLE_KERNEL = np.full((_DOWNSAMPLE_FACTOR,), 1.0 / _DOWNSAMPLE_FACTOR, dtype=np.float32)
+TARGET_FRAME_SIZE = int(round(TARGET_SAMPLE_RATE * 0.08))
 
 
-def _downsample_to_target_rate(
-    pcm: np.ndarray,
-    residual: np.ndarray,
-    *,
-    flush: bool = False,
-) -> tuple[np.ndarray, np.ndarray]:
-    """Downsample a PCM chunk to the target rate, keeping leftover samples.
+class StreamingDownsampler:
+    """Incrementally convert server PCM into the target sample rate."""
 
-    The server emits 24kHz audio. We apply a simple moving-average low-pass filter
-    followed by decimation by three so that the resulting stream matches 8kHz.
-    Any samples that do not fit an even multiple of the downsampling factor are
-    returned as residual and will be prefixed to the next chunk.
-    """
+    def __init__(self, target_rate: int, *, assume_source: int | None = None) -> None:
+        if target_rate <= 0:
+            raise ValueError("Target rate must be positive")
+        self._target_rate = target_rate
+        self._source_rate = None
+        self._factor = 1
+        self._residual = np.array([], dtype=np.float32)
+        if assume_source is not None:
+            self.configure_source_rate(assume_source)
 
-    if TARGET_SAMPLE_RATE == SERVER_SAMPLE_RATE:
-        return pcm.astype(np.float32), np.array([], dtype=np.float32)
+    @property
+    def source_rate(self) -> int | None:
+        return self._source_rate
 
-    if _DOWNSAMPLE_FACTOR * TARGET_SAMPLE_RATE != SERVER_SAMPLE_RATE:
-        msg = (
-            "Expected integer downsample factor between server and target sample rates. "
-            f"Got server={SERVER_SAMPLE_RATE}, target={TARGET_SAMPLE_RATE}."
-        )
-        raise ValueError(msg)
+    def configure_source_rate(self, sample_rate: int) -> None:
+        """(Re)configure the upstream sample rate and reset residuals."""
 
-    if residual.size:
-        pcm = np.concatenate([residual, pcm])
+        if sample_rate <= 0:
+            raise ValueError("Sample rate must be positive")
+        if self._source_rate == sample_rate:
+            return
+        self._source_rate = sample_rate
+        if sample_rate == self._target_rate:
+            self._factor = 1
+        else:
+            if sample_rate % self._target_rate != 0:
+                msg = (
+                    "Expected integer downsample factor between server and target sample rates. "
+                    f"Got server={sample_rate}, target={self._target_rate}."
+                )
+                raise ValueError(msg)
+            self._factor = sample_rate // self._target_rate
+        self._residual = np.array([], dtype=np.float32)
 
-    if flush and pcm.size:
-        pad = (-pcm.size) % _DOWNSAMPLE_FACTOR
-        if pad:
-            pcm = np.pad(pcm, (0, pad))
-    elif pcm.size < _DOWNSAMPLE_FACTOR:
-        return np.array([], dtype=np.float32), pcm
+    def process(self, pcm: np.ndarray, *, flush: bool = False) -> np.ndarray:
+        """Downsample the provided chunk and retain any leftovers for later."""
 
-    trim = pcm.size - (pcm.size % _DOWNSAMPLE_FACTOR)
-    main_chunk = pcm[:trim]
-    residual = pcm[trim:]
+        if self._source_rate is None:
+            raise RuntimeError("Source rate has not been configured yet")
 
-    # Moving-average low-pass filter before decimation to reduce aliasing.
-    filtered = np.convolve(main_chunk, _DOWNSAMPLE_KERNEL, mode="same")
-    downsampled = filtered.reshape(-1, _DOWNSAMPLE_FACTOR).mean(axis=1)
-    return downsampled.astype(np.float32), residual.astype(np.float32)
+        pcm = np.asarray(pcm, dtype=np.float32)
+        if pcm.size == 0 and self._residual.size == 0:
+            return np.array([], dtype=np.float32)
 
+        # Normalise the server PCM if it arrives as 16-bit integers.
+        if pcm.size and np.max(np.abs(pcm)) > 1.0:
+            pcm = pcm / np.float32(np.iinfo(np.int16).max)
+
+        if self._residual.size:
+            pcm = np.concatenate([self._residual, pcm])
+
+        if self._factor == 1:
+            self._residual = np.array([], dtype=np.float32)
+            return pcm
+
+        if flush and pcm.size:
+            pad = (-pcm.size) % self._factor
+            if pad:
+                pcm = np.pad(pcm, (0, pad))
+
+        trim = pcm.size - (pcm.size % self._factor)
+        if trim == 0:
+            if flush and pcm.size:
+                trim = pcm.size
+            else:
+                self._residual = pcm
+                return np.array([], dtype=np.float32)
+
+        main_chunk = pcm[:trim]
+        self._residual = pcm[trim:] if not flush else np.array([], dtype=np.float32)
+
+        # Simple moving-average decimation to reduce aliasing.
+        reshaped = main_chunk.reshape(-1, self._factor)
+        downsampled = reshaped.mean(axis=1)
+        return downsampled.astype(np.float32)
 TTS_TEXT = "Hello, this is a test of the moshi text to speech system, this should result in some nicely sounding generated voice."
 DEFAULT_DSM_TTS_VOICE_REPO = "kyutai/tts-voices"
 AUTH_TOKEN = "public_token"
@@ -82,9 +115,11 @@ async def receive_messages(
     output_queue: asyncio.Queue,
 ):
     with tqdm.tqdm(desc="Receiving audio", unit=" seconds generated") as pbar:
+        downsampler = StreamingDownsampler(
+            TARGET_SAMPLE_RATE, assume_source=DEFAULT_SERVER_SAMPLE_RATE
+        )
         accumulated_samples = 0
         last_seconds = 0
-        residual = np.array([], dtype=np.float32)
         pending_output = np.array([], dtype=np.float32)
 
         try:
@@ -94,8 +129,10 @@ async def receive_messages(
                 if msg["type"] != "Audio":
                     continue
 
-                pcm = np.asarray(msg["pcm"], dtype=np.float32)
-                pcm, residual = _downsample_to_target_rate(pcm, residual)
+                sample_rate = int(msg.get("sample_rate", downsampler.source_rate or DEFAULT_SERVER_SAMPLE_RATE))
+                downsampler.configure_source_rate(sample_rate)
+
+                pcm = downsampler.process(msg["pcm"])
                 if pcm.size:
                     if pending_output.size:
                         pending_output = np.concatenate([pending_output, pcm])
@@ -106,20 +143,18 @@ async def receive_messages(
                         pending_output = pending_output[TARGET_FRAME_SIZE:]
 
                 accumulated_samples += len(msg["pcm"])
-                current_seconds = accumulated_samples // SERVER_SAMPLE_RATE
+                source_rate = downsampler.source_rate or sample_rate
+                current_seconds = accumulated_samples // source_rate
                 if current_seconds > last_seconds:
                     pbar.update(current_seconds - last_seconds)
                     last_seconds = current_seconds
         finally:
-            if residual.size:
-                pcm, _ = _downsample_to_target_rate(
-                    np.array([], dtype=np.float32), residual, flush=True
-                )
-                if pcm.size:
-                    if pending_output.size:
-                        pending_output = np.concatenate([pending_output, pcm])
-                    else:
-                        pending_output = pcm
+            flushed = downsampler.process(np.array([], dtype=np.float32), flush=True)
+            if flushed.size:
+                if pending_output.size:
+                    pending_output = np.concatenate([pending_output, flushed])
+                else:
+                    pending_output = flushed
 
             if pending_output.size:
                 await output_queue.put(pending_output)

--- a/scripts/tts_rust_server.py
+++ b/scripts/tts_rust_server.py
@@ -21,36 +21,107 @@ import sphn
 import tqdm
 import websockets
 
-SAMPLE_RATE = 24000
+# The server currently streams audio at 24kHz. Downsample on the client so that the
+# saved or played audio uses the expected 8kHz cadence.
+SERVER_SAMPLE_RATE = 24000
+TARGET_SAMPLE_RATE = 8000
+TARGET_FRAME_SIZE = TARGET_SAMPLE_RATE // 1000 * 80
+_DOWNSAMPLE_FACTOR = SERVER_SAMPLE_RATE // TARGET_SAMPLE_RATE
+_DOWNSAMPLE_KERNEL = np.full((_DOWNSAMPLE_FACTOR,), 1.0 / _DOWNSAMPLE_FACTOR, dtype=np.float32)
+
+
+def _downsample_to_target_rate(
+    pcm: np.ndarray,
+    residual: np.ndarray,
+    *,
+    flush: bool = False,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Downsample a PCM chunk to the target rate, keeping leftover samples.
+
+    The server emits 24kHz audio. We apply a simple moving-average low-pass filter
+    followed by decimation by three so that the resulting stream matches 8kHz.
+    Any samples that do not fit an even multiple of the downsampling factor are
+    returned as residual and will be prefixed to the next chunk.
+    """
+
+    if TARGET_SAMPLE_RATE == SERVER_SAMPLE_RATE:
+        return pcm.astype(np.float32), np.array([], dtype=np.float32)
+
+    if _DOWNSAMPLE_FACTOR * TARGET_SAMPLE_RATE != SERVER_SAMPLE_RATE:
+        msg = (
+            "Expected integer downsample factor between server and target sample rates. "
+            f"Got server={SERVER_SAMPLE_RATE}, target={TARGET_SAMPLE_RATE}."
+        )
+        raise ValueError(msg)
+
+    if residual.size:
+        pcm = np.concatenate([residual, pcm])
+
+    if flush and pcm.size:
+        pad = (-pcm.size) % _DOWNSAMPLE_FACTOR
+        if pad:
+            pcm = np.pad(pcm, (0, pad))
+    elif pcm.size < _DOWNSAMPLE_FACTOR:
+        return np.array([], dtype=np.float32), pcm
+
+    trim = pcm.size - (pcm.size % _DOWNSAMPLE_FACTOR)
+    main_chunk = pcm[:trim]
+    residual = pcm[trim:]
+
+    # Moving-average low-pass filter before decimation to reduce aliasing.
+    filtered = np.convolve(main_chunk, _DOWNSAMPLE_KERNEL, mode="same")
+    downsampled = filtered.reshape(-1, _DOWNSAMPLE_FACTOR).mean(axis=1)
+    return downsampled.astype(np.float32), residual.astype(np.float32)
 
 TTS_TEXT = "Hello, this is a test of the moshi text to speech system, this should result in some nicely sounding generated voice."
 DEFAULT_DSM_TTS_VOICE_REPO = "kyutai/tts-voices"
 AUTH_TOKEN = "public_token"
 
 
-async def receive_messages(websocket: websockets.ClientConnection, output_queue):
+async def receive_messages(
+    websocket: websockets.ClientConnection,
+    output_queue: asyncio.Queue,
+):
     with tqdm.tqdm(desc="Receiving audio", unit=" seconds generated") as pbar:
         accumulated_samples = 0
         last_seconds = 0
+        residual = np.array([], dtype=np.float32)
+        pending_output = np.array([], dtype=np.float32)
 
         async for message_bytes in websocket:
             msg = msgpack.unpackb(message_bytes)
 
             if msg["type"] == "Audio":
-                pcm = np.array(msg["pcm"]).astype(np.float32)
-                await output_queue.put(pcm)
+                pcm = np.array(msg["pcm"], dtype=np.float32)
+                pcm, residual = _downsample_to_target_rate(pcm, residual)
+                if pcm.size:
+                    pending_output = np.concatenate([pending_output, pcm])
+                    while pending_output.size >= TARGET_FRAME_SIZE:
+                        await output_queue.put(pending_output[:TARGET_FRAME_SIZE])
+                        pending_output = pending_output[TARGET_FRAME_SIZE:]
 
                 accumulated_samples += len(msg["pcm"])
-                current_seconds = accumulated_samples // SAMPLE_RATE
+                current_seconds = accumulated_samples // SERVER_SAMPLE_RATE
                 if current_seconds > last_seconds:
                     pbar.update(current_seconds - last_seconds)
                     last_seconds = current_seconds
 
+        if residual.size:
+            pcm, residual = _downsample_to_target_rate(
+                np.array([], dtype=np.float32),
+                residual,
+                flush=True,
+            )
+            if pcm.size:
+                pending_output = np.concatenate([pending_output, pcm])
+
+        if pending_output.size:
+            await output_queue.put(pending_output)
     print("End of audio.")
     await output_queue.put(None)  # Signal end of audio
 
 
-async def output_audio(out: str, output_queue: asyncio.Queue[np.ndarray | None]):
+async def output_audio(out: str, output_queue: asyncio.Queue):
     if out == "-":
         should_exit = False
 
@@ -60,7 +131,14 @@ async def output_audio(out: str, output_queue: asyncio.Queue[np.ndarray | None])
             try:
                 pcm_data = output_queue.get_nowait()
                 if pcm_data is not None:
-                    outdata[:, 0] = pcm_data
+                    frames = min(pcm_data.size, outdata.shape[0])
+                    outdata[:frames, 0] = pcm_data[:frames]
+                    if frames < outdata.shape[0]:
+                        outdata[frames:, 0] = 0
+                    if pcm_data.size > outdata.shape[0]:
+                        remainder = pcm_data[outdata.shape[0] :]
+                        if remainder.size:
+                            output_queue.put_nowait(remainder)
                 else:
                     should_exit = True
                     outdata[:] = 0
@@ -68,8 +146,8 @@ async def output_audio(out: str, output_queue: asyncio.Queue[np.ndarray | None])
                 outdata[:] = 0
 
         with sd.OutputStream(
-            samplerate=SAMPLE_RATE,
-            blocksize=1920,
+            samplerate=TARGET_SAMPLE_RATE,
+            blocksize=TARGET_FRAME_SIZE,
             channels=1,
             callback=audio_callback,
         ):
@@ -85,7 +163,11 @@ async def output_audio(out: str, output_queue: asyncio.Queue[np.ndarray | None])
                 break
             frames.append(item)
 
-        sphn.write_wav(out, np.concat(frames, -1), SAMPLE_RATE)
+        if frames:
+            pcm = np.concatenate(frames, axis=0)
+        else:
+            pcm = np.array([], dtype=np.float32)
+        sphn.write_wav(out, pcm, TARGET_SAMPLE_RATE)
         print(f"Saved audio to {out}")
 
 

--- a/scripts/tts_rust_server.py
+++ b/scripts/tts_rust_server.py
@@ -132,14 +132,26 @@ async def receive_messages(
                 sample_rate = int(msg.get("sample_rate", downsampler.source_rate or DEFAULT_SERVER_SAMPLE_RATE))
                 downsampler.configure_source_rate(sample_rate)
 
-                pcm = downsampler.process(msg["pcm"])
+                raw_pcm = msg["pcm"]
+                if isinstance(raw_pcm, (bytes, bytearray, memoryview)):
+                    # The streaming API serialises PCM as little-endian
+                    # float32 values. Accept a raw buffer here so the client
+                    # works regardless of how msgpack deserialised the field.
+                    buffer = memoryview(raw_pcm)
+                    pcm = np.frombuffer(buffer, dtype="<f4", count=buffer.nbytes // 4)
+                else:
+                    pcm = np.asarray(raw_pcm, dtype=np.float32)
+
+                pcm = downsampler.process(pcm)
                 if pcm.size:
                     if pending_output.size:
                         pending_output = np.concatenate([pending_output, pcm])
                     else:
                         pending_output = pcm
                     while pending_output.size >= TARGET_FRAME_SIZE:
-                        await output_queue.put(pending_output[:TARGET_FRAME_SIZE])
+                        await output_queue.put(
+                            np.ascontiguousarray(pending_output[:TARGET_FRAME_SIZE])
+                        )
                         pending_output = pending_output[TARGET_FRAME_SIZE:]
 
                 accumulated_samples += len(msg["pcm"])
@@ -157,7 +169,7 @@ async def receive_messages(
                     pending_output = flushed
 
             if pending_output.size:
-                await output_queue.put(pending_output)
+                await output_queue.put(np.ascontiguousarray(pending_output))
 
             print("End of audio.")
             await output_queue.put(None)  # Signal end of audio
@@ -203,6 +215,7 @@ async def output_audio(out: str, output_queue: asyncio.Queue):
             channels=1,
             callback=audio_callback,
         ):
+            print(f"Output stream initialised at {TARGET_SAMPLE_RATE} Hz")
             while not should_exit:
                 await asyncio.sleep(0.05)
     else:

--- a/scripts/tts_rust_server.py
+++ b/scripts/tts_rust_server.py
@@ -3,7 +3,6 @@
 # dependencies = [
 #     "msgpack",
 #     "numpy",
-#     "sphn",
 #     "websockets",
 #     "sounddevice",
 #     "tqdm",
@@ -17,7 +16,7 @@ from urllib.parse import urlencode
 import msgpack
 import numpy as np
 import sounddevice as sd
-import sphn
+import wave
 import tqdm
 import websockets
 
@@ -167,7 +166,22 @@ async def output_audio(out: str, output_queue: asyncio.Queue):
             pcm = np.concatenate(frames, axis=0)
         else:
             pcm = np.array([], dtype=np.float32)
-        sphn.write_wav(out, pcm, TARGET_SAMPLE_RATE)
+
+        # Persist the file with an explicit 8 kHz WAV header so that downstream
+        # tools correctly read the sample rate regardless of third party
+        # library quirks.
+        with wave.open(out, "wb") as wav_file:
+            wav_file.setnchannels(1)
+            wav_file.setsampwidth(2)
+            wav_file.setframerate(TARGET_SAMPLE_RATE)
+            if pcm.size:
+                clipped = np.clip(pcm, -1.0, 1.0)
+                int16_pcm = np.round(
+                    clipped * float(np.iinfo(np.int16).max)
+                ).astype("<i2")
+                wav_file.writeframes(int16_pcm.tobytes())
+            else:
+                wav_file.writeframes(b"")
         print(f"Saved audio to {out}")
 
 

--- a/scripts/tts_rust_server.py
+++ b/scripts/tts_rust_server.py
@@ -87,14 +87,20 @@ async def receive_messages(
         residual = np.array([], dtype=np.float32)
         pending_output = np.array([], dtype=np.float32)
 
-        async for message_bytes in websocket:
-            msg = msgpack.unpackb(message_bytes)
+        try:
+            async for message_bytes in websocket:
+                msg = msgpack.unpackb(message_bytes)
 
-            if msg["type"] == "Audio":
-                pcm = np.array(msg["pcm"], dtype=np.float32)
+                if msg["type"] != "Audio":
+                    continue
+
+                pcm = np.asarray(msg["pcm"], dtype=np.float32)
                 pcm, residual = _downsample_to_target_rate(pcm, residual)
                 if pcm.size:
-                    pending_output = np.concatenate([pending_output, pcm])
+                    if pending_output.size:
+                        pending_output = np.concatenate([pending_output, pcm])
+                    else:
+                        pending_output = pcm
                     while pending_output.size >= TARGET_FRAME_SIZE:
                         await output_queue.put(pending_output[:TARGET_FRAME_SIZE])
                         pending_output = pending_output[TARGET_FRAME_SIZE:]
@@ -104,45 +110,57 @@ async def receive_messages(
                 if current_seconds > last_seconds:
                     pbar.update(current_seconds - last_seconds)
                     last_seconds = current_seconds
+        finally:
+            if residual.size:
+                pcm, _ = _downsample_to_target_rate(
+                    np.array([], dtype=np.float32), residual, flush=True
+                )
+                if pcm.size:
+                    if pending_output.size:
+                        pending_output = np.concatenate([pending_output, pcm])
+                    else:
+                        pending_output = pcm
 
-        if residual.size:
-            pcm, residual = _downsample_to_target_rate(
-                np.array([], dtype=np.float32),
-                residual,
-                flush=True,
-            )
-            if pcm.size:
-                pending_output = np.concatenate([pending_output, pcm])
+            if pending_output.size:
+                await output_queue.put(pending_output)
 
-        if pending_output.size:
-            await output_queue.put(pending_output)
-    print("End of audio.")
-    await output_queue.put(None)  # Signal end of audio
+            print("End of audio.")
+            await output_queue.put(None)  # Signal end of audio
 
 
 async def output_audio(out: str, output_queue: asyncio.Queue):
     if out == "-":
         should_exit = False
+        stop_requested = False
+        pending_local = np.array([], dtype=np.float32)
 
-        def audio_callback(outdata, _a, _b, _c):
-            nonlocal should_exit
+        def audio_callback(outdata, _frames, _time, _status):
+            nonlocal should_exit, stop_requested, pending_local
 
-            try:
-                pcm_data = output_queue.get_nowait()
-                if pcm_data is not None:
-                    frames = min(pcm_data.size, outdata.shape[0])
-                    outdata[:frames, 0] = pcm_data[:frames]
-                    if frames < outdata.shape[0]:
-                        outdata[frames:, 0] = 0
-                    if pcm_data.size > outdata.shape[0]:
-                        remainder = pcm_data[outdata.shape[0] :]
-                        if remainder.size:
-                            output_queue.put_nowait(remainder)
+            if pending_local.size < outdata.shape[0] and not stop_requested:
+                try:
+                    next_chunk = output_queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    next_chunk = None
                 else:
-                    should_exit = True
-                    outdata[:] = 0
-            except asyncio.QueueEmpty:
-                outdata[:] = 0
+                    if next_chunk is None:
+                        stop_requested = True
+                    elif next_chunk.size:
+                        if pending_local.size:
+                            pending_local = np.concatenate([pending_local, next_chunk])
+                        else:
+                            pending_local = next_chunk
+
+            frames = min(pending_local.size, outdata.shape[0])
+            if frames:
+                outdata[:frames, 0] = pending_local[:frames]
+            if frames < outdata.shape[0]:
+                outdata[frames:, 0] = 0
+            if frames:
+                pending_local = pending_local[frames:]
+
+            if stop_requested and pending_local.size == 0:
+                should_exit = True
 
         with sd.OutputStream(
             samplerate=TARGET_SAMPLE_RATE,
@@ -150,10 +168,8 @@ async def output_audio(out: str, output_queue: asyncio.Queue):
             channels=1,
             callback=audio_callback,
         ):
-            while True:
-                if should_exit:
-                    break
-                await asyncio.sleep(1)
+            while not should_exit:
+                await asyncio.sleep(0.05)
     else:
         frames = []
         while True:
@@ -182,7 +198,9 @@ async def output_audio(out: str, output_queue: asyncio.Queue):
                 wav_file.writeframes(int16_pcm.tobytes())
             else:
                 wav_file.writeframes(b"")
-        print(f"Saved audio to {out}")
+        with wave.open(out, "rb") as wav_file:
+            reported_rate = wav_file.getframerate()
+        print(f"Saved audio to {out} (sample rate: {reported_rate} Hz)")
 
 
 async def read_lines_from_stdin():
@@ -258,10 +276,18 @@ async def websocket_client():
 
         async def send_loop():
             print("go send")
-            async for line in get_lines(args.inp):
-                for word in line.split():
-                    await websocket.send(msgpack.packb({"type": "Text", "text": word}))
-            await websocket.send(msgpack.packb({"type": "Eos"}))
+            try:
+                async for line in get_lines(args.inp):
+                    for word in line.split():
+                        await websocket.send(
+                            msgpack.packb({"type": "Text", "text": word})
+                        )
+                await websocket.send(msgpack.packb({"type": "Eos"}))
+            except websockets.ConnectionClosed:
+                # The server closed the connection before we finished streaming.
+                # This typically happens after it finishes synthesis. Swallow the
+                # error so the receive loop can drain the remaining audio.
+                pass
 
         output_queue = asyncio.Queue()
         receive_task = asyncio.create_task(receive_messages(websocket, output_queue))

--- a/stt-rs/src/main.rs
+++ b/stt-rs/src/main.rs
@@ -6,6 +6,9 @@ use anyhow::Result;
 use candle::{Device, Tensor};
 use clap::Parser;
 
+const SAMPLE_RATE: usize = 8_000;
+const CHUNK_SIZE: usize = SAMPLE_RATE / 1000 * 80; // 80ms chunks
+
 #[derive(Debug, Parser)]
 struct Args {
     /// The audio input file, in wav/mp3/ogg/... format.
@@ -175,16 +178,16 @@ impl Model {
         // Add the silence prefix to the audio.
         if self.config.stt_config.audio_silence_prefix_seconds > 0.0 {
             let silence_len =
-                (self.config.stt_config.audio_silence_prefix_seconds * 24000.0) as usize;
+                (self.config.stt_config.audio_silence_prefix_seconds * SAMPLE_RATE as f64) as usize;
             pcm.splice(0..0, vec![0.0; silence_len]);
         }
         // Add some silence at the end to ensure all the audio is processed.
-        let suffix = (self.config.stt_config.audio_delay_seconds * 24000.0) as usize;
-        pcm.resize(pcm.len() + suffix + 24000, 0.0);
+        let suffix = (self.config.stt_config.audio_delay_seconds * SAMPLE_RATE as f64) as usize;
+        pcm.resize(pcm.len() + suffix + SAMPLE_RATE, 0.0);
 
         let mut last_word = None;
         let mut printed_eot = false;
-        for pcm in pcm.chunks(1920) {
+        for pcm in pcm.chunks(CHUNK_SIZE) {
             let pcm = Tensor::new(pcm, &self.dev)?.reshape((1, 1, ()))?;
             let asr_msgs = self.state.step_pcm(pcm, None, &().into(), |_, _, _| ())?;
             for asr_msg in asr_msgs.iter() {
@@ -247,8 +250,9 @@ fn main() -> Result<()> {
 
     println!("Loading audio file from: {}", args.in_file);
     let (pcm, sample_rate) = kaudio::pcm_decode(&args.in_file)?;
-    let pcm = if sample_rate != 24_000 {
-        kaudio::resample(&pcm, sample_rate as usize, 24_000)?
+    let sample_rate = sample_rate as usize;
+    let pcm = if sample_rate != SAMPLE_RATE {
+        kaudio::resample(&pcm, sample_rate, SAMPLE_RATE)?
     } else {
         pcm
     };


### PR DESCRIPTION
## Summary
- add shared constants in the Rust CLI to downsample audio to 8 kHz and adjust chunk sizing
- update the resampling logic and silence padding to use the new constants
- align the Python streaming clients with the 8 kHz sample rate and 80 ms frame size

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68d2927cac6c8322ad76f55234072d95