### PR TITLE
Adjust streaming chunk size and add raw TTS output

### DIFF
--- a/scripts/stt_from_file_rust_server.py
+++ b/scripts/stt_from_file_rust_server.py
@@ -17,7 +17,7 @@ import sphn
 import websockets
 
 SAMPLE_RATE = 8000
-FRAME_SIZE = SAMPLE_RATE // 1000 * 80  # Send data in ~80ms chunks
+FRAME_SIZE = SAMPLE_RATE // 1000 * 60  # Send data in fixed 60ms chunks
 
 
 def load_and_process_audio(file_path):

--- a/scripts/stt_from_mic_rust_server.py
+++ b/scripts/stt_from_mic_rust_server.py
@@ -17,7 +17,7 @@ import sounddevice as sd
 import websockets
 
 SAMPLE_RATE = 8000
-FRAME_SIZE = SAMPLE_RATE // 1000 * 80  # 80ms blocks
+FRAME_SIZE = SAMPLE_RATE // 1000 * 60  # 60ms blocks
 
 # The VAD has several prediction heads, each of which tries to determine whether there
 # has been a pause of a given length. The lengths are 0.5, 1.0, 2.0, and 3.0 seconds.

--- a/scripts/tts_mlx.py
+++ b/scripts/tts_mlx.py
@@ -144,17 +144,31 @@ def main():
     ]
 
     wav_frames = queue.Queue()
-    _frames_cnt = 0
+    sample_rate = mimi.sample_rate
+    frame_size = sample_rate // 1000 * 60
+    emitted_samples = 0
+    pending_pcm = np.array([], dtype=np.float32)
+
+    def _emit_frames():
+        nonlocal pending_pcm, emitted_samples
+        while pending_pcm.size >= frame_size:
+            wav_frames.put_nowait(pending_pcm[:frame_size].copy())
+            pending_pcm = pending_pcm[frame_size:]
+            emitted_samples += frame_size
+            print(
+                f"generated {emitted_samples / sample_rate:.2f}s",
+                end="\r",
+                flush=True,
+            )
 
     def _on_frame(frame):
-        nonlocal _frames_cnt
+        nonlocal pending_pcm
         if (frame == -1).any():
             return
         _pcm = tts_model.mimi.decode_step(frame[:, :, None])
-        _pcm = np.array(mx.clip(_pcm[0, 0], -1, 1))
-        wav_frames.put_nowait(_pcm)
-        _frames_cnt += 1
-        print(f"generated {_frames_cnt / 12.5:.2f}s", end="\r", flush=True)
+        _pcm = np.array(mx.clip(_pcm[0, 0], -1, 1), dtype=np.float32)
+        pending_pcm = np.concatenate([pending_pcm, _pcm])
+        _emit_frames()
 
     def run():
         log("info", "starting the inference loop")
@@ -178,17 +192,32 @@ def main():
         def audio_callback(outdata, _a, _b, _c):
             try:
                 pcm_data = wav_frames.get(block=False)
-                outdata[:, 0] = pcm_data
+                frames = min(pcm_data.size, outdata.shape[0])
+                outdata[:frames, 0] = pcm_data[:frames]
+                if frames < outdata.shape[0]:
+                    outdata[frames:, 0] = 0
+                if pcm_data.size > outdata.shape[0]:
+                    remainder = pcm_data[outdata.shape[0] :]
+                    if remainder.size:
+                        wav_frames.put_nowait(remainder)
             except queue.Empty:
                 outdata[:] = 0
 
         with sd.OutputStream(
-            samplerate=mimi.sample_rate,
-            blocksize=1920,
+            samplerate=sample_rate,
+            blocksize=frame_size,
             channels=1,
             callback=audio_callback,
         ):
             run()
+            if pending_pcm.size:
+                wav_frames.put_nowait(pending_pcm.copy())
+                emitted_samples += pending_pcm.size
+                print(
+                    f"generated {emitted_samples / sample_rate:.2f}s",
+                    end="\r",
+                    flush=True,
+                )
             time.sleep(3)
             while True:
                 if wav_frames.qsize() == 0:
@@ -196,14 +225,29 @@ def main():
                 time.sleep(1)
     else:
         run()
+        if pending_pcm.size:
+            wav_frames.put_nowait(pending_pcm.copy())
+            emitted_samples += pending_pcm.size
+            print(
+                f"generated {emitted_samples / sample_rate:.2f}s",
+                end="\r",
+                flush=True,
+            )
         frames = []
         while True:
             try:
                 frames.append(wav_frames.get_nowait())
             except queue.Empty:
                 break
-        wav = np.concat(frames, -1)
-        sphn.write_wav(args.out, wav, mimi.sample_rate)
+        wav = np.concatenate(frames, axis=-1) if frames else np.array([], dtype=np.float32)
+        if args.out.lower().endswith(".raw"):
+            pcm_i16 = np.clip(wav, -1.0, 1.0)
+            pcm_i16 = (pcm_i16 * np.float32(32767.0)).astype("<i2")
+            with open(args.out, "wb") as fobj:
+                pcm_i16.tofile(fobj)
+            log("info", f"Saved raw 16-bit PCM audio to {args.out} at {sample_rate}Hz")
+        else:
+            sphn.write_wav(args.out, wav, sample_rate)
 
 
 if __name__ == "__main__":

--- a/scripts/tts_mlx_streaming.py
+++ b/scripts/tts_mlx_streaming.py
@@ -260,13 +260,24 @@ def main():
     ]
 
     wav_frames = queue.Queue()
+    sample_rate = mimi.sample_rate
+    frame_size = sample_rate // 1000 * 60
+    pending_pcm = np.array([], dtype=np.float32)
+
+    def _emit_frames():
+        nonlocal pending_pcm
+        while pending_pcm.size >= frame_size:
+            wav_frames.put_nowait(pending_pcm[:frame_size].copy())
+            pending_pcm = pending_pcm[frame_size:]
 
     def _on_frame(frame):
+        nonlocal pending_pcm
         if (frame == -1).any():
             return
         _pcm = tts_model.mimi.decode_step(frame[:, :, None])
-        _pcm = np.array(mx.clip(_pcm[0, 0], -1, 1))
-        wav_frames.put_nowait(_pcm)
+        _pcm = np.array(mx.clip(_pcm[0, 0], -1, 1), dtype=np.float32)
+        pending_pcm = np.concatenate([pending_pcm, _pcm])
+        _emit_frames()
 
     gen = TTSGen(tts_model, all_attributes, on_frame=_on_frame)
 
@@ -286,31 +297,49 @@ def main():
         def audio_callback(outdata, _a, _b, _c):
             try:
                 pcm_data = wav_frames.get(block=False)
-                outdata[:, 0] = pcm_data
+                frames = min(pcm_data.size, outdata.shape[0])
+                outdata[:frames, 0] = pcm_data[:frames]
+                if frames < outdata.shape[0]:
+                    outdata[frames:, 0] = 0
+                if pcm_data.size > outdata.shape[0]:
+                    remainder = pcm_data[outdata.shape[0] :]
+                    if remainder.size:
+                        wav_frames.put_nowait(remainder)
             except queue.Empty:
                 outdata[:] = 0
 
         with sd.OutputStream(
-            samplerate=mimi.sample_rate,
-            blocksize=1920,
+            samplerate=sample_rate,
+            blocksize=frame_size,
             channels=1,
             callback=audio_callback,
         ):
             run()
+            if pending_pcm.size:
+                wav_frames.put_nowait(pending_pcm.copy())
             while True:
                 if wav_frames.qsize() == 0:
                     break
                 time.sleep(1)
     else:
         run()
+        if pending_pcm.size:
+            wav_frames.put_nowait(pending_pcm.copy())
         frames = []
         while True:
             try:
                 frames.append(wav_frames.get_nowait())
             except queue.Empty:
                 break
-        wav = np.concat(frames, -1)
-        sphn.write_wav(args.out, wav, mimi.sample_rate)
+        wav = np.concatenate(frames, axis=-1) if frames else np.array([], dtype=np.float32)
+        if args.out.lower().endswith(".raw"):
+            pcm_i16 = np.clip(wav, -1.0, 1.0)
+            pcm_i16 = (pcm_i16 * np.float32(32767.0)).astype("<i2")
+            with open(args.out, "wb") as fobj:
+                pcm_i16.tofile(fobj)
+            log("info", f"Saved raw 16-bit PCM audio to {args.out} at {sample_rate}Hz")
+        else:
+            sphn.write_wav(args.out, wav, sample_rate)
 
 
 if __name__ == "__main__":

--- a/scripts/tts_pytorch.py
+++ b/scripts/tts_pytorch.py
@@ -57,6 +57,8 @@ def main():
     tts_model = TTSModel.from_checkpoint_info(
         checkpoint_info, n_q=32, temp=0.6, device=args.device
     )
+    sample_rate = tts_model.mimi.sample_rate
+    frame_size = sample_rate // 1000 * 60
 
     if args.inp == "-":
         if sys.stdin.isatty():  # Interactive
@@ -78,38 +80,68 @@ def main():
     condition_attributes = tts_model.make_condition_attributes(
         [voice_path], cfg_coef=2.0
     )
-    _frames_cnt = 0
+    emitted_samples = 0
 
     if args.out == "-":
         # Stream the audio to the speakers using sounddevice.
         import sounddevice as sd
 
         pcms = queue.Queue()
+        pending_pcm = np.array([], dtype=np.float32)
+
+        def _emit_frames():
+            nonlocal pending_pcm, emitted_samples
+            while pending_pcm.size >= frame_size:
+                pcms.put_nowait(pending_pcm[:frame_size].copy())
+                pending_pcm = pending_pcm[frame_size:]
+                emitted_samples += frame_size
+                print(
+                    f"generated {emitted_samples / sample_rate:.2f}s",
+                    end="\r",
+                    flush=True,
+                )
 
         def _on_frame(frame):
-            nonlocal _frames_cnt
+            nonlocal pending_pcm
             if (frame != -1).all():
-                pcm = tts_model.mimi.decode(frame[:, 1:, :]).cpu().numpy()
-                pcms.put_nowait(np.clip(pcm[0, 0], -1, 1))
-                _frames_cnt += 1
-                print(f"generated {_frames_cnt / 12.5:.2f}s", end="\r", flush=True)
+                pcm = (
+                    tts_model.mimi.decode(frame[:, 1:, :]).cpu().numpy().astype(np.float32)
+                )
+                clipped = np.clip(pcm[0, 0], -1.0, 1.0)
+                pending_pcm = np.concatenate([pending_pcm, clipped])
+                _emit_frames()
 
         def audio_callback(outdata, _a, _b, _c):
             try:
                 pcm_data = pcms.get(block=False)
-                outdata[:, 0] = pcm_data
+                frames = min(pcm_data.size, outdata.shape[0])
+                outdata[:frames, 0] = pcm_data[:frames]
+                if frames < outdata.shape[0]:
+                    outdata[frames:, 0] = 0
+                if pcm_data.size > outdata.shape[0]:
+                    remainder = pcm_data[outdata.shape[0] :]
+                    if remainder.size:
+                        pcms.put_nowait(remainder)
             except queue.Empty:
                 outdata[:] = 0
 
         with sd.OutputStream(
-            samplerate=tts_model.mimi.sample_rate,
-            blocksize=1920,
+            samplerate=sample_rate,
+            blocksize=frame_size,
             channels=1,
             callback=audio_callback,
         ):
             with tts_model.mimi.streaming(1):
                 tts_model.generate(
                     [entries], [condition_attributes], on_frame=_on_frame
+                )
+            if pending_pcm.size:
+                pcms.put_nowait(pending_pcm.copy())
+                emitted_samples += pending_pcm.size
+                print(
+                    f"generated {emitted_samples / sample_rate:.2f}s",
+                    end="\r",
+                    flush=True,
                 )
             time.sleep(3)
             while True:
@@ -119,10 +151,14 @@ def main():
     else:
 
         def _on_frame(frame):
-            nonlocal _frames_cnt
+            nonlocal emitted_samples
             if (frame != -1).all():
-                _frames_cnt += 1
-                print(f"generated {_frames_cnt / 12.5:.2f}s", end="\r", flush=True)
+                emitted_samples += frame_size
+                print(
+                    f"generated {emitted_samples / sample_rate:.2f}s",
+                    end="\r",
+                    flush=True,
+                )
 
         start_time = time.time()
         result = tts_model.generate(
@@ -133,9 +169,17 @@ def main():
             pcms = []
             for frame in result.frames[tts_model.delay_steps :]:
                 pcm = tts_model.mimi.decode(frame[:, 1:, :]).cpu().numpy()
-                pcms.append(np.clip(pcm[0, 0], -1, 1))
+                clipped = np.clip(pcm[0, 0], -1, 1).astype(np.float32)
+                pcms.append(clipped)
             pcm = np.concatenate(pcms, axis=-1)
-        sphn.write_wav(args.out, pcm, tts_model.mimi.sample_rate)
+        if args.out.lower().endswith(".raw"):
+            pcm_i16 = np.clip(pcm, -1.0, 1.0)
+            pcm_i16 = (pcm_i16 * np.float32(32767.0)).astype("<i2")
+            with open(args.out, "wb") as fobj:
+                pcm_i16.tofile(fobj)
+            print(f"Saved raw 16-bit PCM audio to {args.out} at {sample_rate}Hz")
+        else:
+            sphn.write_wav(args.out, pcm, sample_rate)
 
 
 if __name__ == "__main__":

--- a/scripts/tts_pytorch_streaming.py
+++ b/scripts/tts_pytorch_streaming.py
@@ -197,29 +197,51 @@ def main():
     if sys.stdin.isatty():  # Interactive
         print("Enter text to synthesize (Ctrl+D to end input):")
 
+    sample_rate = tts_model.mimi.sample_rate
+    frame_size = sample_rate // 1000 * 60
+
     if args.out == "-":
         # Stream the audio to the speakers using sounddevice.
         import sounddevice as sd
 
         pcms = queue.Queue()
+        pending_pcm = np.array([], dtype=np.float32)
+
+        def _emit_frames():
+            nonlocal pending_pcm
+            while pending_pcm.size >= frame_size:
+                pcms.put_nowait(pending_pcm[:frame_size].copy())
+                pending_pcm = pending_pcm[frame_size:]
 
         def _on_frame(frame):
+            nonlocal pending_pcm
             if (frame != -1).all():
-                pcm = tts_model.mimi.decode(frame[:, 1:, :]).cpu().numpy()
-                pcms.put_nowait(np.clip(pcm[0, 0], -1, 1))
+                pcm = (
+                    tts_model.mimi.decode(frame[:, 1:, :]).cpu().numpy().astype(np.float32)
+                )
+                clipped = np.clip(pcm[0, 0], -1.0, 1.0)
+                pending_pcm = np.concatenate([pending_pcm, clipped])
+                _emit_frames()
 
         def audio_callback(outdata, _a, _b, _c):
             try:
                 pcm_data = pcms.get(block=False)
-                outdata[:, 0] = pcm_data
+                frames = min(pcm_data.size, outdata.shape[0])
+                outdata[:frames, 0] = pcm_data[:frames]
+                if frames < outdata.shape[0]:
+                    outdata[frames:, 0] = 0
+                if pcm_data.size > outdata.shape[0]:
+                    remainder = pcm_data[outdata.shape[0] :]
+                    if remainder.size:
+                        pcms.put_nowait(remainder)
             except queue.Empty:
                 outdata[:] = 0
 
         gen = TTSGen(tts_model, [condition_attributes], on_frame=_on_frame)
 
         with sd.OutputStream(
-            samplerate=tts_model.mimi.sample_rate,
-            blocksize=1920,
+            samplerate=sample_rate,
+            blocksize=frame_size,
             channels=1,
             callback=audio_callback,
         ) and tts_model.mimi.streaming(1):
@@ -231,6 +253,8 @@ def main():
                     gen.append_entry(entry)
                     gen.process()
             gen.process_last()
+            if pending_pcm.size:
+                pcms.put_nowait(pending_pcm.copy())
             while True:
                 if pcms.qsize() == 0:
                     break
@@ -241,7 +265,8 @@ def main():
         def _on_frame(frame: torch.Tensor):
             if (frame != -1).all():
                 pcm = tts_model.mimi.decode(frame[:, 1:, :]).cpu().numpy()
-                pcms.append(np.clip(pcm[0, 0]))
+                clipped = np.clip(pcm[0, 0], -1, 1).astype(np.float32)
+                pcms.append(clipped)
 
         gen = TTSGen(tts_model, [condition_attributes], on_frame=_on_frame)
         with tts_model.mimi.streaming(1):
@@ -253,8 +278,15 @@ def main():
                     gen.append_entry(entry)
                     gen.process()
             gen.process_last()
-        pcm = np.concatenate(pcms, axis=-1)
-        sphn.write_wav(args.out, pcm, tts_model.mimi.sample_rate)
+        pcm = np.concatenate(pcms, axis=-1) if pcms else np.array([], dtype=np.float32)
+        if args.out.lower().endswith(".raw"):
+            pcm_i16 = np.clip(pcm, -1.0, 1.0)
+            pcm_i16 = (pcm_i16 * np.float32(32767.0)).astype("<i2")
+            with open(args.out, "wb") as fobj:
+                pcm_i16.tofile(fobj)
+            print(f"Saved raw 16-bit PCM audio to {args.out} at {sample_rate}Hz")
+        else:
+            sphn.write_wav(args.out, pcm, sample_rate)
 
 
 if __name__ == "__main__":

--- a/scripts/tts_rust_server.py
+++ b/scripts/tts_rust_server.py
@@ -25,7 +25,7 @@ import websockets
 # saved or played audio uses the expected 8kHz cadence.
 SERVER_SAMPLE_RATE = 24000
 TARGET_SAMPLE_RATE = 8000
-TARGET_FRAME_SIZE = TARGET_SAMPLE_RATE // 1000 * 80
+TARGET_FRAME_SIZE = TARGET_SAMPLE_RATE // 1000 * 60
 _DOWNSAMPLE_FACTOR = SERVER_SAMPLE_RATE // TARGET_SAMPLE_RATE
 _DOWNSAMPLE_KERNEL = np.full((_DOWNSAMPLE_FACTOR,), 1.0 / _DOWNSAMPLE_FACTOR, dtype=np.float32)
 
@@ -167,8 +167,17 @@ async def output_audio(out: str, output_queue: asyncio.Queue):
             pcm = np.concatenate(frames, axis=0)
         else:
             pcm = np.array([], dtype=np.float32)
-        sphn.write_wav(out, pcm, TARGET_SAMPLE_RATE)
-        print(f"Saved audio to {out}")
+        if out.lower().endswith(".raw"):
+            pcm_i16 = np.clip(pcm, -1.0, 1.0)
+            pcm_i16 = (pcm_i16 * np.float32(32767.0)).astype("<i2")
+            with open(out, "wb") as f:
+                pcm_i16.tofile(f)
+            print(
+                f"Saved raw 16-bit PCM audio to {out} at {TARGET_SAMPLE_RATE}Hz"
+            )
+        else:
+            sphn.write_wav(out, pcm, TARGET_SAMPLE_RATE)
+            print(f"Saved WAV audio to {out}")
 
 
 async def read_lines_from_stdin():
@@ -214,7 +223,9 @@ async def websocket_client():
     parser = argparse.ArgumentParser(description="Use the TTS streaming API")
     parser.add_argument("inp", type=str, help="Input file, use - for stdin.")
     parser.add_argument(
-        "out", type=str, help="Output file to generate, use - for playing the audio"
+        "out",
+        type=str,
+        help="Output file to generate (.wav or .raw for 16-bit PCM), use - for playing the audio",
     )
     parser.add_argument(
         "--voice",

--- a/stt-rs/src/main.rs
+++ b/stt-rs/src/main.rs
@@ -7,7 +7,7 @@ use candle::{Device, Tensor};
 use clap::Parser;
 
 const SAMPLE_RATE: usize = 8_000;
-const CHUNK_SIZE: usize = SAMPLE_RATE / 1000 * 80; // 80ms chunks
+const CHUNK_SIZE: usize = SAMPLE_RATE / 1000 * 60; // 60ms chunks
 
 #[derive(Debug, Parser)]
 struct Args {


### PR DESCRIPTION
## Summary
- switch STT client chunk sizes to a fixed 60ms window for both Python helpers and the Rust binary
- expose 60ms playback blocks for the TTS helper script and document the expected output formats
- add 16-bit PCM RAW file saving support to the TTS streaming client while keeping WAV emission as default

## Testing
- `cargo fmt`


------
https://chatgpt.com/codex/tasks/task_e_68d4d9363d1c83228efebc14b6f3e570