### PR TITLE
Buffer rust server transcript before printing

### DIFF
--- a/scripts/stt_from_file_rust_server.py
+++ b/scripts/stt_from_file_rust_server.py
@@ -36,7 +36,6 @@ async def receive_messages(websocket):
             # much audio the server has already processed. We don't use either here.
             continue
         if data["type"] == "Word":
-            print(data["text"], end=" ", flush=True)
             transcript.append(
                 {
                     "text": data["text"],
@@ -127,7 +126,10 @@ if __name__ == "__main__":
     url = f"{args.url}/api/asr-streaming"
     transcript = asyncio.run(stream_audio(url, args.api_key, args.rtf))
 
-    print()
+    if transcript:
+        final_text = " ".join(word["text"] for word in transcript)
+        print(final_text)
+
     print()
     for word in transcript:
         print(


### PR DESCRIPTION
## Summary
- stop streaming word-level output from the rust server client helper
- collect the transcript and only emit the complete text once processing finishes
- add a final joined transcript summary before the per-word timestamp table

## Testing
- python -m compileall scripts/stt_from_file_rust_server.py

------
https://chatgpt.com/codex/tasks/task_e_68d4ee52dc5483229a933f0689e94127